### PR TITLE
Fail busy jobs on shutdown

### DIFF
--- a/src/worker.ts
+++ b/src/worker.ts
@@ -247,6 +247,13 @@ export class Worker extends EventEmitter {
         debug("shutdown timeout exceeded");
         forced = true;
         // @TODO fail in progress jobs so they retry faster
+
+        debug("failing in progress");
+        for (const jid of this.working.keys()) {
+          debug(`failed job ${jid}`);
+          await this.client.fail(jid, new Error("Restarting worker"));
+        }
+
         this.client.close();
         resolve();
         process.exit(1);


### PR DESCRIPTION
When the worker process goes away and we have long running jobs they can essentially get orphaned. We then have to wait until the reserveFor time expires before they get started again, this can often be quite a long time.

This commit fails all busy jobs such that they land in the retry queue and get started as soon as a worker comes back online.

I wanted to add tests but currently in core they're all skipped?

Once merged we should also open a PR in Remus to use our fork